### PR TITLE
Add -re option to handle exceptions when loading files gracefully

### DIFF
--- a/de4dot.cui/CommandLineParser.cs
+++ b/de4dot.cui/CommandLineParser.cs
@@ -107,6 +107,12 @@ namespace de4dot.cui {
 					ExitError("Missing -r option");
 				searchDir.SkipUnknownObfuscators = true;
 			}));
+			miscOptions.Add(new NoArgOption("re", null, "Skip recursively found files that throw an exception on load", () => {
+				if (searchDir == null)
+					ExitError("Missing -r option");
+				searchDir.AllowFileLoadError = true;
+			}));
+			
 			miscOptions.Add(new NoArgOption("d", null, "Detect obfuscators and exit", () => {
 				filesOptions.DetectObfuscators = true;
 			}));

--- a/de4dot.cui/FilesDeobfuscator.cs
+++ b/de4dot.cui/FilesDeobfuscator.cs
@@ -75,6 +75,7 @@ namespace de4dot.cui {
 			public string InputDirectory { get; set; }
 			public string OutputDirectory { get; set; }
 			public bool SkipUnknownObfuscators { get; set; }
+			public bool AllowFileLoadError { get; set; }
 		}
 
 		public FilesDeobfuscator(Options options) => this.options = options;
@@ -262,7 +263,15 @@ namespace de4dot.cui {
 				}
 				if (ok) {
 					foreach (var filename in DoDirectoryInfo(searchDir, di)) {
-						var obfuscatedFile = CreateObfuscatedFile(searchDir, filename);
+						IObfuscatedFile obfuscatedFile = null;
+						try {
+							obfuscatedFile =  CreateObfuscatedFile(searchDir, filename);
+						}catch (Exception ex){
+							if (!searchDir.AllowFileLoadError)
+								throw;
+							Logger.Instance.Log(false, null, LoggerEvent.Warning, "Could not load file {0} Use -v to see stack trace", filename);
+							Program.PrintStackTrace(ex, LoggerEvent.Verbose);
+						}
 						if (obfuscatedFile != null)
 							yield return obfuscatedFile;
 					}					


### PR DESCRIPTION
Allows you to be a bit lazier in terms of cleaning out non .net (or unloadable .net) files from the target directory. 