### PR TITLE
cflow: Allow overflows for Int64 shifts too

### DIFF
--- a/de4dot.blocks/cflow/Int32Value.cs
+++ b/de4dot.blocks/cflow/Int32Value.cs
@@ -450,8 +450,6 @@ namespace de4dot.blocks.cflow {
 				return CreateUnknown();
 			if (b.Value == 0)
 				return a;
-			//if (b.Value < 0 || b.Value >= sizeof(int) * 8)
-			//	return CreateUnknown();
 			int shift = b.Value;
 			uint validMask = (a.ValidMask << shift) | (uint.MaxValue >> (sizeof(int) * 8 - shift));
 			return new Int32Value(a.Value << shift, validMask);
@@ -462,8 +460,6 @@ namespace de4dot.blocks.cflow {
 				return CreateUnknown();
 			if (b.Value == 0)
 				return a;
-			//if (b.Value < 0 || b.Value >= sizeof(int) * 8)
-			//	return CreateUnknown();
 			int shift = b.Value;
 			uint validMask = a.ValidMask >> shift;
 			if (a.IsBitValid(sizeof(int) * 8 - 1))
@@ -476,8 +472,6 @@ namespace de4dot.blocks.cflow {
 				return CreateUnknown();
 			if (b.Value == 0)
 				return a;
-			//if (b.Value < 0 || b.Value >= sizeof(int) * 8)
-			//	return CreateUnknown();
 			int shift = b.Value;
 			uint validMask = (a.ValidMask >> shift) | (uint.MaxValue << (sizeof(int) * 8 - shift));
 			return new Int32Value((int)((uint)a.Value >> shift), validMask);

--- a/de4dot.blocks/cflow/Int64Value.cs
+++ b/de4dot.blocks/cflow/Int64Value.cs
@@ -393,8 +393,6 @@ namespace de4dot.blocks.cflow {
 				return CreateUnknown();
 			if (b.Value == 0)
 				return a;
-			if (b.Value < 0 || b.Value >= sizeof(long) * 8)
-				return CreateUnknown();
 			int shift = b.Value;
 			ulong validMask = (a.ValidMask << shift) | (ulong.MaxValue >> (sizeof(long) * 8 - shift));
 			return new Int64Value(a.Value << shift, validMask);
@@ -405,8 +403,6 @@ namespace de4dot.blocks.cflow {
 				return CreateUnknown();
 			if (b.Value == 0)
 				return a;
-			if (b.Value < 0 || b.Value >= sizeof(long) * 8)
-				return CreateUnknown();
 			int shift = b.Value;
 			ulong validMask = a.ValidMask >> shift;
 			if (a.IsBitValid(sizeof(long) * 8 - 1))
@@ -419,8 +415,6 @@ namespace de4dot.blocks.cflow {
 				return CreateUnknown();
 			if (b.Value == 0)
 				return a;
-			if (b.Value < 0 || b.Value >= sizeof(long) * 8)
-				return CreateUnknown();
 			int shift = b.Value;
 			ulong validMask = (a.ValidMask >> shift) | (ulong.MaxValue << (sizeof(long) * 8 - shift));
 			return new Int64Value((long)((ulong)a.Value >> shift), validMask);


### PR DESCRIPTION
The checks were already disabled for Int32.

Fixes #6.